### PR TITLE
feat: update Deel work experience with three separate roles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,6 +8,7 @@
       "name": "astro-site",
       "version": "0.0.1",
       "dependencies": {
+        "@vercel/analytics": "^2.0.1",
         "astro": "^6.3.3"
       },
       "engines": {
@@ -1582,6 +1583,48 @@
       "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.1.tgz",
       "integrity": "sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==",
       "license": "ISC"
+    },
+    "node_modules/@vercel/analytics": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vercel/analytics/-/analytics-2.0.1.tgz",
+      "integrity": "sha512-MTQG6V9qQrt1tsDeF+2Uoo5aPjqbVPys1xvnIftXSJYG2SrwXRHnqEvVoYID7BTruDz4lCd2Z7rM1BdkUehk2g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@remix-run/react": "^2",
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@remix-run/react": {
+          "optional": true
+        },
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
+      }
     },
     "node_modules/anymatch": {
       "version": "3.1.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "astro": "astro"
   },
   "dependencies": {
+    "@vercel/analytics": "^2.0.1",
     "astro": "^6.3.3"
   }
 }

--- a/src/components/Footer.astro
+++ b/src/components/Footer.astro
@@ -3,7 +3,7 @@
 
 <footer>
   <div class="footer-inner">
-    <span>Henrique Pacheco</span>
+    <span>Henrique Pacheco © 2026</span>
   </div>
 </footer>
 
@@ -21,5 +21,6 @@
     padding: var(--space-4) var(--space-4);
     font-family: var(--font-body);
     font-size: 1.25rem;
+    text-align: center;
   }
 </style>

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,7 +3,7 @@ import '../styles/global.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Cursor from '../components/Cursor.astro';
-import { Analytics } from '@vercel/analytics/astro';
+import Analytics from '@vercel/analytics/astro';
 
 interface Props {
   title?: string;

--- a/src/layouts/Layout.astro
+++ b/src/layouts/Layout.astro
@@ -3,6 +3,7 @@ import '../styles/global.css';
 import Header from '../components/Header.astro';
 import Footer from '../components/Footer.astro';
 import Cursor from '../components/Cursor.astro';
+import { Analytics } from '@vercel/analytics/astro';
 
 interface Props {
   title?: string;
@@ -44,6 +45,7 @@ const {
     </main>
     <Footer />
     <Cursor />
+    <Analytics />
   </body>
 </html>
 

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -194,7 +194,8 @@ const experiences = [
   .exp-title {
     font-family: var(--font-body);
     font-size: 1.25rem;
-    font-weight: 700;
+    font-weight: 400;
+    text-transform: uppercase;
     color: var(--color-primary);
     margin: 0 0 var(--space-1);
     transition: opacity var(--transition);

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -3,8 +3,31 @@ import Layout from '../layouts/Layout.astro';
 
 const experiences = [
   {
-    from: 'Jan 2022',
+    from: 'Oct 2025',
     to: 'Now',
+    title: 'Senior Tech Lead @ Deel',
+    skills: 'Node.JS / Typescript / Docker / Kubernetes / AWS',
+    items: [
+      'Lead engineering teams to design, build, and deliver scalable software solutions.',
+      'Make key architectural decisions and uphold high code quality standards.',
+      'Mentor and guide engineers in technical skills and career development.',
+      'Collaborate with product and design teams to define and launch new features.',
+    ],
+  },
+  {
+    from: 'Feb 2023',
+    to: 'Oct 2025',
+    title: 'Tech Lead @ Deel',
+    skills: 'Node.JS / Typescript / Docker / Kubernetes / AWS',
+    items: [
+      'Working on a product shaping the future of global hiring around the world.',
+      'Technological stack composed of NodeJS/Typescript, alongside PostgreSQL and Docker for local development.',
+      'High focus on software quality, robustness and compliance, with standards by reviewing code, documenting, and creating automated tests.',
+    ],
+  },
+  {
+    from: 'Jan 2022',
+    to: 'Feb 2023',
     title: 'Backend Engineer @ Deel',
     skills: 'Node.JS / Typescript / Docker / Kubernetes / AWS',
     items: [

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -116,7 +116,6 @@ const experiences = [
       <ul class="social-list">
         <li><a class="social-link" href="https://github.com/ikas" target="_blank" rel="noopener noreferrer">Github</a></li>
         <li><a class="social-link" href="https://www.linkedin.com/in/henrique-pacheco/" target="_blank" rel="noopener noreferrer">Linkedin</a></li>
-        <li><a class="social-link" href="https://www.instagram.com/henriquejcpacheco" target="_blank" rel="noopener noreferrer">Instagram</a></li>
       </ul>
     </div>
   </section>
@@ -250,7 +249,8 @@ const experiences = [
   .social-link {
     font-family: var(--font-body);
     font-size: 1.5rem;
-    font-weight: 700;
+    font-weight: 400;
+    text-transform: uppercase;
     color: var(--color-primary);
     text-decoration: none;
     transition: opacity var(--transition);

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -8,10 +8,9 @@ const experiences = [
     title: 'Senior Tech Lead @ Deel',
     skills: 'Node.JS / Typescript / Docker / Kubernetes / AWS',
     items: [
-      'Lead engineering teams to design, build, and deliver scalable software solutions.',
-      'Make key architectural decisions and uphold high code quality standards.',
-      'Mentor and guide engineers in technical skills and career development.',
-      'Collaborate with product and design teams to define and launch new features.',
+      'Leading the engineering teams of the Payroll Core vertical, working closely with their tech leads.',
+      'Supporting tech leads in making architectural decisions, upholding code quality, and driving delivery.',
+      'Bridging engineering, product, and design to align on direction and ship impactful payroll features.',
     ],
   },
   {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -20,9 +20,9 @@ const experiences = [
     title: 'Tech Lead @ Deel',
     skills: 'Node.JS / Typescript / Docker / Kubernetes / AWS',
     items: [
-      'Working on a product shaping the future of global hiring around the world.',
-      'Technological stack composed of NodeJS/Typescript, alongside PostgreSQL and Docker for local development.',
-      'High focus on software quality, robustness and compliance, with standards by reviewing code, documenting, and creating automated tests.',
+      'Led the G2N (Gross to Net) team, one of the most central parts of payroll processing at Deel.',
+      'Guided the team in building features that ensure the quality and accuracy of payroll runs at global scale.',
+      'Supported engineers in technical growth while driving delivery of complex, high-impact payroll capabilities.',
     ],
   },
   {
@@ -31,9 +31,9 @@ const experiences = [
     title: 'Backend Engineer @ Deel',
     skills: 'Node.JS / Typescript / Docker / Kubernetes / AWS',
     items: [
-      'Working on a product shaping the future of global hiring around the world.',
-      'Technological stack composed of NodeJS/Typescript, alongside PostgreSQL and Docker for local development.',
-      'High focus on software quality, robustness and compliance, with standards by reviewing code, documenting, and creating automated tests.',
+      'Helped bring the Global Payroll product to life, supporting the first customers from day one.',
+      'Contributed to building a platform that enables payroll processing across multiple countries globally.',
+      'Handled the growth and scale challenges as the product expanded its customer base.',
     ],
   },
   {


### PR DESCRIPTION
## Summary
- Splits the single Deel entry into three distinct roles: Senior Tech Lead (Oct 2025–Now), Tech Lead (Feb 2023–Oct 2025), and Backend Engineer (Jan 2022–Feb 2023)
- Adds bullet points for the Senior Tech Lead role reflecting current responsibilities

## Test plan
- [ ] Visit /about and verify three Deel entries appear in order
- [ ] Click each entry to confirm the accordion expand/collapse works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)