### PR TITLE
feat: fix subtitle wrapping and add retrofoot.fun highlight

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -92,6 +92,15 @@ const experiences = [
       <p class="bio">Want to know more?</p>
       <a class="contact-link" href="mailto:henriquejcpacheco@gmail.com">Get in touch</a>
 
+      <h2 class="section-heading projects-heading">Side Projects</h2>
+      <div class="project-item">
+        <div class="project-header">
+          <p class="project-name">retrofoot.fun</p>
+          <a class="project-link" href="https://retrofoot.fun" target="_blank" rel="noopener noreferrer">Visit ↗</a>
+        </div>
+        <p class="project-desc">A browser-based clone of a simple football manager game I loved as a kid. You pick a squad, make transfers, and guide your team through a season — built from scratch as a passion project to recreate that nostalgic experience.</p>
+      </div>
+
       <h2 class="section-heading exp-heading">Experience</h2>
       <div class="experience-list" id="experience-list">
         {experiences.map((exp, idx) => (
@@ -140,8 +149,54 @@ const experiences = [
     margin: 0 0 var(--space-4);
   }
 
+  .projects-heading {
+    margin-top: var(--space-6);
+  }
+
   .exp-heading {
     margin-top: var(--space-6);
+  }
+
+  .project-item {
+    margin-bottom: var(--space-5);
+  }
+
+  .project-header {
+    display: flex;
+    align-items: baseline;
+    gap: var(--space-4);
+    margin-bottom: var(--space-2);
+  }
+
+  .project-name {
+    font-family: var(--font-body);
+    font-size: 1.25rem;
+    font-weight: 400;
+    text-transform: uppercase;
+    color: var(--color-primary);
+    margin: 0;
+  }
+
+  .project-link {
+    font-family: var(--font-body);
+    font-size: 0.9rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--color-tertiary);
+    text-decoration: none;
+    letter-spacing: 0.05em;
+    transition: opacity var(--transition);
+  }
+
+  .project-link:hover {
+    opacity: 0.7;
+  }
+
+  .project-desc {
+    font-size: 1rem;
+    line-height: 1.6;
+    color: var(--color-primary-70);
+    margin: 0;
   }
 
   .bio {

--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -98,7 +98,7 @@ const experiences = [
           <p class="project-name">retrofoot.fun</p>
           <a class="project-link" href="https://retrofoot.fun" target="_blank" rel="noopener noreferrer">Visit ↗</a>
         </div>
-        <p class="project-desc">A browser-based clone of a simple football manager game I loved as a kid. You pick a squad, make transfers, and guide your team through a season — built from scratch as a passion project to recreate that nostalgic experience.</p>
+        <p class="project-desc">A browser-based clone of Elifoot 98, a simple football manager game I loved as a kid. You pick a squad, make transfers, and guide your team through a season — built from scratch as a passion project to recreate that nostalgic experience.</p>
       </div>
 
       <h2 class="section-heading exp-heading">Experience</h2>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -8,6 +8,12 @@ import Layout from '../layouts/Layout.astro';
       <h1 class="hero-name">Henrique<br />Pacheco</h1>
       <p class="hero-sub">Software Engineer from Portugal</p>
     </section>
+
+    <a class="side-project" href="https://retrofoot.fun" target="_blank" rel="noopener noreferrer">
+      <span class="side-project-label">Side Project</span>
+      <span class="side-project-name">retrofoot.fun ↗</span>
+      <span class="side-project-desc">Football manager clone</span>
+    </a>
   </div>
 </Layout>
 
@@ -17,6 +23,7 @@ import Layout from '../layouts/Layout.astro';
   }
 
   .home-wrapper {
+    position: relative;
     display: flex;
     flex-direction: column;
     height: calc(100vh - 80px);
@@ -52,17 +59,60 @@ import Layout from '../layouts/Layout.astro';
     font-size: 30px;
     line-height: 33px;
     color: var(--color-primary-90);
-    width: 50%;
+    white-space: nowrap;
     margin: var(--space-4) auto 0;
+  }
+
+  .side-project {
+    position: absolute;
+    bottom: var(--space-5);
+    right: var(--space-5);
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+    text-decoration: none;
+    border: 1px solid var(--color-light-gray);
+    padding: var(--space-3) var(--space-4);
+    transition: border-color var(--transition), opacity var(--transition);
+  }
+
+  .side-project:hover {
+    border-color: var(--color-secondary);
+    opacity: 0.8;
+  }
+
+  .side-project-label {
+    font-family: var(--font-body);
+    font-size: 0.7rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-tertiary);
+  }
+
+  .side-project-name {
+    font-family: var(--font-body);
+    font-size: 1rem;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--color-primary);
+  }
+
+  .side-project-desc {
+    font-family: var(--font-body);
+    font-size: 0.8rem;
+    color: var(--color-primary-70);
   }
 
   @media (max-width: 768px) {
     .hero-name { font-size: 100px; line-height: 100px; -webkit-text-stroke: 4px transparent; }
-    .hero-sub { font-size: 26px; line-height: 29px; width: 80%; }
+    .hero-sub { font-size: 26px; line-height: 29px; }
+    .side-project { bottom: var(--space-4); right: var(--space-4); }
   }
 
   @media (max-width: 544px) {
     .hero-name { font-size: 56px; line-height: 56px; -webkit-text-stroke: 2px transparent; }
     .hero-sub { font-size: 20px; line-height: 22px; }
+    .side-project { bottom: var(--space-3); right: var(--space-3); padding: var(--space-2) var(--space-3); }
   }
 </style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,9 +10,7 @@ import Layout from '../layouts/Layout.astro';
     </section>
 
     <a class="side-project" href="https://retrofoot.fun" target="_blank" rel="noopener noreferrer">
-      <span class="side-project-label">Side Project</span>
-      <span class="side-project-name">retrofoot.fun ↗</span>
-      <span class="side-project-desc">Football manager clone</span>
+      Check out my side project: <span class="side-project-name">retrofoot.fun</span> ↗
     </a>
   </div>
 </Layout>
@@ -67,41 +65,20 @@ import Layout from '../layouts/Layout.astro';
     position: absolute;
     bottom: var(--space-5);
     right: var(--space-5);
-    display: flex;
-    flex-direction: column;
-    gap: 2px;
+    font-family: var(--font-body);
+    font-size: 0.85rem;
+    font-weight: 400;
+    color: var(--color-primary-70);
     text-decoration: none;
-    border: 1px solid var(--color-light-gray);
-    padding: var(--space-3) var(--space-4);
-    transition: border-color var(--transition), opacity var(--transition);
+    transition: opacity var(--transition);
   }
 
   .side-project:hover {
-    border-color: var(--color-secondary);
-    opacity: 0.8;
-  }
-
-  .side-project-label {
-    font-family: var(--font-body);
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.1em;
-    color: var(--color-tertiary);
+    opacity: 0.6;
   }
 
   .side-project-name {
-    font-family: var(--font-body);
-    font-size: 1rem;
-    font-weight: 700;
-    text-transform: uppercase;
     color: var(--color-primary);
-  }
-
-  .side-project-desc {
-    font-family: var(--font-body);
-    font-size: 0.8rem;
-    color: var(--color-primary-70);
   }
 
   @media (max-width: 768px) {
@@ -113,6 +90,6 @@ import Layout from '../layouts/Layout.astro';
   @media (max-width: 544px) {
     .hero-name { font-size: 56px; line-height: 56px; -webkit-text-stroke: 2px transparent; }
     .hero-sub { font-size: 20px; line-height: 22px; }
-    .side-project { bottom: var(--space-3); right: var(--space-3); padding: var(--space-2) var(--space-3); }
+    .side-project { bottom: var(--space-3); right: var(--space-3); }
   }
 </style>


### PR DESCRIPTION
## Summary

- Fix "Software Engineer from Portugal" subtitle so it never wraps to a second line (replaced `width: 50%` with `white-space: nowrap`)
- Add a minimal bottom-right widget on the homepage linking to [retrofoot.fun](https://retrofoot.fun), styled with the existing design tokens
- Add a **Side Projects** section on the About page with a short description of retrofoot.fun

## Test plan

- [ ] Homepage subtitle renders on a single line at all viewport sizes
- [ ] Side project widget is visible in the bottom-right corner of the homepage and links to retrofoot.fun
- [ ] About page shows the Side Projects section above Experience with the correct link

🤖 Generated with [Claude Code](https://claude.com/claude-code)